### PR TITLE
Fix weight increment in HEADERS and PRIORITY frames

### DIFF
--- a/connection_handler.go
+++ b/connection_handler.go
@@ -107,7 +107,7 @@ func parseHTTP2(f *http2.Framer, c chan ParsedFrame) {
 
 			prio := Priority{}
 			p.Priority = &prio
-			// 6.2: Weight: An 8-bit weight for the stream; Add one to the value to obtain a weight between 1 and 256
+			// 6.3: Weight: An 8-bit weight for the stream; Add one to the value to obtain a weight between 1 and 256
 			p.Priority.Weight = int(frame.PriorityParam.Weight) + 1
 			p.Priority.DependsOn = int(frame.PriorityParam.StreamDep)
 			if frame.PriorityParam.Exclusive {

--- a/connection_handler.go
+++ b/connection_handler.go
@@ -92,8 +92,8 @@ func parseHTTP2(f *http2.Framer, c chan ParsedFrame) {
 			if frame.HasPriority() {
 				prio := Priority{}
 				p.Priority = &prio
-				// I really dont know why we need +1 here, but its one less than the actual value
-				p.Priority.Weight = int(frame.Priority.Weight + 1)
+				// 6.2: Weight: An 8-bit weight for the stream; Add one to the value to obtain a weight between 1 and 256
+				p.Priority.Weight = int(frame.Priority.Weight) + 1
 				p.Priority.DependsOn = int(frame.Priority.StreamDep)
 				if frame.Priority.Exclusive {
 					p.Priority.Exclusive = 1
@@ -107,8 +107,8 @@ func parseHTTP2(f *http2.Framer, c chan ParsedFrame) {
 
 			prio := Priority{}
 			p.Priority = &prio
-			// I really dont know why we need +1 here, but its one less than the actual value
-			p.Priority.Weight = int(frame.PriorityParam.Weight + 1)
+			// 6.2: Weight: An 8-bit weight for the stream; Add one to the value to obtain a weight between 1 and 256
+			p.Priority.Weight = int(frame.PriorityParam.Weight) + 1
 			p.Priority.DependsOn = int(frame.PriorityParam.StreamDep)
 			if frame.PriorityParam.Exclusive {
 				p.Priority.Exclusive = 1


### PR DESCRIPTION
Priority Frame: [Section 6.3](https://datatracker.ietf.org/doc/html/rfc7540#section-6.3)
Headers Frame: [Section 6.3](https://datatracker.ietf.org/doc/html/rfc7540#section-6.2)

Both sections mention the following:
> Weight:  An unsigned 8-bit integer representing a priority weight for
 the stream (see [Section 5.3](https://datatracker.ietf.org/doc/html/rfc7540#section-5.3)).  Add one to the value to obtain a
 weight between 1 and 256.  This field is only present if the
 PRIORITY flag is set.

The weight from both frames is not converted from a uint8 (to make space for 256) before incrementing, which results in it overflowing to 0.

Moving the existing int conversion to the uint8 value before incrementing solves this.