### PR TITLE
fixed possible random order in flags output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ TrackMe
 .DS_Store
 requests-db/
 config.json
+.idea


### PR DESCRIPTION
This is just related to the output - not the handling of flags and has as far as i can tell no effect on the fingerprinting itself.

I often compare the JSON Result from my browser with my implemented client result and just throw both into a text diff checker tool.

The flags sometimes sorted differently due to the fact that we range over a map and the order there is random: https://go.dev/blog/maps