### PR TITLE
Add parsing support for extensions

### DIFF
--- a/handshake_names.go
+++ b/handshake_names.go
@@ -532,3 +532,47 @@ func GetCurveNameByID(id uint16) string {
 	}
 	return fmt.Sprintf("Unknown curve %d", id)
 }
+
+var signatures = map[uint16]string{
+	513:  "rsa_pkcs1_sha1",
+	515:  "ecdsa_sha1",
+	1025: "rsa_pkcs1_sha256",
+	1027: "ecdsa_secp256r1_sha256",
+	1056: "rsa_pkcs1_sha256_legacy",
+	1281: "rsa_pkcs1_sha384",
+	1283: "ecdsa_secp384r1_sha384",
+	1312: "rsa_pkcs1_sha384_legacy",
+	1537: "rsa_pkcs1_sha512",
+	1539: "ecdsa_secp521r1_sha512",
+	1568: "rsa_pkcs1_sha512_legacy",
+	1796: "eccsi_sha256",
+	1797: "iso_ibs1",
+	1798: "iso_ibs2",
+	1799: "iso_chinese_ibs",
+	1800: "sm2sig_sm3",
+	1801: "gostr34102012_256a",
+	1802: "gostr34102012_256b",
+	1803: "gostr34102012_256c",
+	1804: "gostr34102012_256d",
+	1805: "gostr34102012_512a",
+	1806: "gostr34102012_512b",
+	1807: "gostr34102012_512c",
+	2052: "rsa_pss_rsae_sha256",
+	2053: "rsa_pss_rsae_sha384",
+	2054: "rsa_pss_rsae_sha512",
+	2055: "ed25519",
+	2056: "ed25519",
+	2057: "rsa_pss_pss_sha256",
+	2058: "rsa_pss_pss_sha384",
+	2059: "rsa_pss_pss_sha512",
+	2074: "ecdsa_brainpoolP256r1tls13_sha256",
+	2075: "ecdsa_brainpoolP384r1tls13_sha384",
+	2076: "ecdsa_brainpoolP512r1tls13_sha512",
+}
+
+func GetSignaturesNameByID(id uint16) string {
+	if name, ok := signatures[id]; ok {
+		return name
+	}
+	return fmt.Sprintf("Unknown Signature %d", id)
+}

--- a/handshake_names.go
+++ b/handshake_names.go
@@ -570,9 +570,9 @@ var signatures = map[uint16]string{
 	2076: "ecdsa_brainpoolP512r1tls13_sha512",
 }
 
-func GetSignaturesNameByID(id uint16) string {
+func GetSignatureNameByID(id uint16) string {
 	if name, ok := signatures[id]; ok {
 		return name
 	}
-	return fmt.Sprintf("Unknown Signature %d", id)
+	return fmt.Sprintf("0x%x", id)
 }

--- a/main.go
+++ b/main.go
@@ -32,6 +32,11 @@ func init() {
 	if err != nil {
 		log.Fatal(err)
 	}
+	
+	if len(c.MongoURL) == 0 { // Don't attempt to setup mongo if its not populated in the config
+		return
+	}
+	
 	clientOptions := options.Client().ApplyURI(c.MongoURL)
 	client, err = mongo.Connect(ctx, clientOptions)
 	if err != nil {

--- a/parse_client_hello.go
+++ b/parse_client_hello.go
@@ -262,6 +262,12 @@ func parseRawExtensions(exts []Extension, chp ClientHello) ([]interface{}, Clien
 			}
 
 			tmp = c
+		case "0012":
+			tmp = struct {
+				Name        string `json:"name"`
+			} {
+				Name:		"signed_certificate_timestamp (18)",
+			}
 		case "0015": // padding
 			tmp = struct {
 				Name        string `json:"name"`

--- a/parse_client_hello.go
+++ b/parse_client_hello.go
@@ -212,6 +212,21 @@ func parseRawExtensions(exts []Extension, chp ClientHello) ([]interface{}, Clien
 				chp.SupportedPoints = []uint8{0x00}
 			}
 			tmp = c
+		case "000d": // signature_algorithms
+			c := struct {
+				Name       string `json:"name"`
+				AlgsLength int      `json:"-"`
+				Algorithms []string `json:"signature_algorithms"`
+			}{
+				Name:      "signature_algorithms (13)",
+				AlgsLength:	hexToInt(d[0:4]) / 2,
+			}
+			tmpC := 4
+			for tmpC <= c.AlgsLength*4{
+				c.Algorithms = append(c.Algorithms, GetSignaturesNameByID(uint16(hexToInt(d[tmpC:tmpC+4]))))
+				tmpC += 4
+			}
+			tmp = c
 		case "0010": // application_layer_protocol_negotiation
 			c := struct {
 				Name                string   `json:"name"`

--- a/parse_client_hello.go
+++ b/parse_client_hello.go
@@ -324,6 +324,24 @@ func parseRawExtensions(exts []Extension, chp ClientHello) ([]interface{}, Clien
 				count += 4
 			}
 			tmp = c
+		case "002d": // psk_key_exchange_modes
+			// https://www.rfc-editor.org/rfc/rfc8446#section-4.2.9
+			mapping := map[int]string{
+				0: "PSK-only key establishment (psk) (0)",
+				1: "PSK with (EC)DHE key establishment (psk_dhe_ke) (1)",
+			}
+			
+			c := struct {
+				Name                      string `json:"name"`
+				PSKKeyExchangeModesLength int `json:"PSK_Key_Exchange_Modes_Length"`
+				PSKKeyExchangeMode        string `json:"PSK_Key_Exchange_Mode"`
+				
+			}{
+				Name: "psk_key_exchange_modes ",
+				PSKKeyExchangeModesLength: hexToInt(d[0:2]),
+				PSKKeyExchangeMode: mapping[hexToInt(d[2:4])],
+			}
+			tmp = c
 		case "4469": // application_settings
 			c := struct {
 				Name       string   `json:"name"`

--- a/parse_client_hello.go
+++ b/parse_client_hello.go
@@ -175,6 +175,17 @@ func parseRawExtensions(exts []Extension, chp ClientHello) ([]interface{}, Clien
 			c.ServerName = hexToString(d[10:])
 
 			tmp = c
+		case "0005":
+			c := struct {
+				Name            string        `json:"name"`
+				StatusRequest   StatusRequest `json:"status_request"`
+			}{
+				Name: "status_request",
+			}
+			c.StatusRequest.CertificateStatusType = fmt.Sprintf("OSCP (%d)", hexToInt(d[0:2]))
+			c.StatusRequest.ResponderIDListLength = hexToInt(d[2:4])
+			c.StatusRequest.RequestExtensionsLength = hexToInt(d[4:6])
+			tmp = c
 		case "000a": // supported_groups
 			c := struct {
 				Name            string   `json:"name"`

--- a/parse_client_hello.go
+++ b/parse_client_hello.go
@@ -188,7 +188,7 @@ func parseRawExtensions(exts []Extension, chp ClientHello) ([]interface{}, Clien
 				if isGrease("0x" + strings.ToUpper(val)) {
 					c.SupportedGroups = append(c.SupportedGroups, "TLS_GREASE (0x"+val+")")
 				} else {
-					c.SupportedGroups = append(c.SupportedGroups, "0x"+val)
+					c.SupportedGroups = append(c.SupportedGroups, GetCurveNameByID(uint16(hexToInt(val))))
 					chp.SupportedCurves = append(chp.SupportedCurves, uint8(hexToInt(val)))
 				}
 				tmpC += 4

--- a/parse_client_hello.go
+++ b/parse_client_hello.go
@@ -233,7 +233,7 @@ func parseRawExtensions(exts []Extension, chp ClientHello) ([]interface{}, Clien
 				ALPNExtensionLength int      `json:"-"`
 				Protocols           []string `json:"protocols"`
 			}{
-				Name:                "application_layer_protocol_negotiation",
+				Name:                "application_layer_protocol_negotiation (16)",
 				ALPNExtensionLength: hexToInt(d[0:4]),
 			}
 			tmpC := 4

--- a/parse_client_hello.go
+++ b/parse_client_hello.go
@@ -175,7 +175,12 @@ func parseRawExtensions(exts []Extension, chp ClientHello) ([]interface{}, Clien
 			c.ServerName = hexToString(d[10:])
 
 			tmp = c
-		case "0005":
+		case "0005": // status_request
+			type StatusRequest struct {
+				CertificateStatusType	string `json:"certificate_status_type"`
+				ResponderIDListLength	int    `json:"responder_id_list_length"`
+				RequestExtensionsLength int    `json:"request_extensions_length"`
+			}
 			c := struct {
 				Name            string        `json:"name"`
 				StatusRequest   StatusRequest `json:"status_request"`

--- a/parse_client_hello.go
+++ b/parse_client_hello.go
@@ -306,7 +306,10 @@ func parseRawExtensions(exts []Extension, chp ClientHello) ([]interface{}, Clien
 			c.Name = "compress_certificate (27)"
 			c.AlgsLength = hexToInt(d[:2])
 			count := 2
-			mapping := map[string]string{"0002": "brotli (2)"}
+			mapping := map[string]string{
+				"0001": "zlib (1)",
+				"0002": "brotli (2)",
+			}
 			for len(c.Algorithms)*2 < c.AlgsLength {
 				c.Algorithms = append(c.Algorithms, getOrReturnOG(d[count:count+4], mapping))
 				count += 4

--- a/structs.go
+++ b/structs.go
@@ -122,9 +122,3 @@ func (c *Config) MakeDefault() {
 	c.KeyFile = "certs/key.pem"
 	c.MongoURL = ""
 }
-
-type StatusRequest struct {
-	CertificateStatusType	string `json:"certificate_status_type"`
-	ResponderIDListLength	int    `json:"responder_id_list_length"`
-	RequestExtensionsLength int    `json:"request_extensions_length"`
-}

--- a/structs.go
+++ b/structs.go
@@ -122,3 +122,9 @@ func (c *Config) MakeDefault() {
 	c.KeyFile = "certs/key.pem"
 	c.MongoURL = ""
 }
+
+type StatusRequest struct {
+	CertificateStatusType	string `json:"certificate_status_type"`
+	ResponderIDListLength	int    `json:"responder_id_list_length"`
+	RequestExtensionsLength int    `json:"request_extensions_length"`
+}


### PR DESCRIPTION
- The following error is generated if MongoURL is left blank in the config.json `error parsing uri: scheme must be "mongodb" or "mongodb+srv"`
- Parse signature_algorithms extension correctly
- Add ID to application_layer_protocol_negotiation
- Fix supported_groups extension display
- Parse status_request extension correctly
- Parse psk_key_exchange_modes extension correctly