### PR TITLE
Fix Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,19 @@
-FROM golang:1.23-alpine
+FROM golang:1.24-alpine
 
 RUN apk add build-base
 RUN apk add libpcap-dev
 WORKDIR /app
 
-COPY go.mod go.sum config.json ./
-COPY *.go ./
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY cmd ./cmd/
+COPY pkg ./pkg/
 COPY certs ./certs/
 COPY static ./static/
 
-RUN go mod download
 RUN go build -o ./out/app ./cmd/main.go
+
+COPY config.json ./
 
 CMD [ "./out/app" ]


### PR DESCRIPTION
1. The app requires go 1.24 now.
2. The docker image was missing `cmd/` and `pkg/` - so the builds were failing.

3. Improved caching by running `go mod download` before copying the source code. That means if only the source code changes, Docker won't rerun `go mod download`.